### PR TITLE
Add CIDR configuration to the relayed data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This interface layer will set the following states, as appropriate:
     been related. The charm should call the following methods to provide the
     appropriate information to the clients:
 
-    * `{relation_name}.set_configuration(mtu=mtu, subnet=subnet)`
+    * `{relation_name}.set_configuration(mtu=mtu, subnet=subnet, cidr=cidr)`
 
 Example:
 
@@ -61,6 +61,8 @@ And the consuming python code:
 @when('flannel.sdn.configured', 'sdn-plugin.connected')
 def relay_sdn_configuration(host):
 
+  config = hookenv.config()
+
   with open('/var/run/flannel/subnet.env') as f:
       flannel_config = f.readlines()
 
@@ -72,7 +74,7 @@ def relay_sdn_configuration(host):
           value = f.split('=')[1].strip()
           mtu = value
 
-    host.send_sdn_info(mtu, subnet)
+    host.send_sdn_info(mtu, subnet, hookenv.config('cidr'))
 ```
 
 

--- a/provides.py
+++ b/provides.py
@@ -41,4 +41,5 @@ class SDNPluginProvider(RelationBase):
         conv = self.conversation()
         config['mtu'] = conv.get_remote('mtu')
         config['subnet'] = conv.get_remote('subnet')
+        config['cidr'] = conv.get_remote('cidr')
         return config

--- a/requires.py
+++ b/requires.py
@@ -33,7 +33,7 @@ class SDNPluginClient(RelationBase):
         self.remove_state('{relation_name}.available')
         self.remove_state('{relation_name}.connected')
 
-    def set_configuration(self, mtu, subnet):
+    def set_configuration(self, mtu, subnet, cidr):
         ''' Set the configuration keys on the wire '''
         conv = self.conversation()
-        conv.set_remote(data={'mtu': mtu, 'subnet': subnet})
+        conv.set_remote(data={'mtu': mtu, 'subnet': subnet, 'cidr': cidr})


### PR DESCRIPTION
Necessary when detailing the ip range in kubernetes-apiserver setup
