### PR TITLE
remove the available state when any of the configuration options are unset

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -31,6 +31,8 @@ class SDNPluginProvider(RelationBase):
         # made of the .available state
         if config['mtu'] and config['subnet'] and config['cidr']:
             conv.set_state('{relation_name}.available')
+        else:
+            conv.remove_state('{relation_name}.available')
 
     @hook('{provides:sdn-plugin}-relation-{departed}')
     def broken_or_departed(self):


### PR DESCRIPTION
Testing successful. If you want to repro, I built the following charms with this PR's change to the sdn interface:

cs:~ryeterrell/xenial/kubernetes-master-1
cs:~ryeterrell/xenial/kubernetes-worker-9
cs:~ryeterrell/xenial/flannel-0

[Here's the associated bundle.](https://gist.github.com/wwwtyro/3d7890a59c14ecc2aa4b74c735d5e2b4)

After executing `juju remove-application kubernetes-master`, the unit status was:

```
kubernetes-master/0*      terminated  executing  8        10.246.67.17    6443/tcp         (stop) 
  filebeat/0*             active      idle                10.246.67.17                     Filebeat ready.
  flannel/0*              active      idle                10.246.67.17                     Flannel subnet 10.1.4.1/24
```

This persists until the `filebeat` and `flannel` applications are removed, at which point the `kubernetes-master/0` unit is finally removed along with its machine. No errors were encountered.

@chuckbutler @mbruzek @Cynerva 

https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/96
